### PR TITLE
Fix storage account name to be random for global uniqueness

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -19,3 +19,23 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:bc96d3bc3d122f81fea271bba5104ba32860d5e84f03da19751e5e8cb883ebef",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.0.2"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
   }
 
   required_version = ">= 1.1.0"
@@ -36,10 +40,19 @@ resource "azurerm_virtual_network" "vnet" {
   }
 }
 
+# Generate random value for the storage account name
+resource "random_string" "general_storage_account_suffix" {
+  length  = 8
+  lower   = true
+  numeric = false
+  special = false
+  upper   = false
+}
+
 # Create an ADLS Gen2 storage account
 # Using cool access tier and locally redundant storage for cost control
 resource "azurerm_storage_account" "adls" {
-  name                     = var.general_storage_account_name
+  name                     = "${var.general_storage_account_prefix}${random_string.general_storage_account_suffix.result}"
   resource_group_name      = azurerm_resource_group.rg.name
   location                 = var.deployment_location
   account_tier             = "Standard"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,7 +13,7 @@ variable "virtual_network_name" {
   default = "dev-vnet"
 }
 
-variable "general_storage_account_name" {
-  description = "ADLS storage account for general object storage"
-  default = "dev-adls"
+variable "general_storage_account_prefix" {
+  description = "Prefix for ADLS storage account for general object storage"
+  default = "devadls"
 }


### PR DESCRIPTION
Azure storage account names must be globally unique. This changes adds a randomly generated string as a suffix to the account name. 