### PR TITLE
Add UC storage, move random resource to separate file

### DIFF
--- a/terraform/random.tf
+++ b/terraform/random.tf
@@ -1,0 +1,8 @@
+# Generate random value to make resource names globally unique
+resource "random_string" "random_suffix" {
+  length  = 12
+  lower   = true
+  numeric = false
+  special = false
+  upper   = false
+}

--- a/terraform/role_assignments.tf
+++ b/terraform/role_assignments.tf
@@ -26,6 +26,13 @@ resource "azurerm_role_assignment" "sp_subscription_contributor" {
   principal_id         = azurerm_user_assigned_identity.primary_service_principal.principal_id
 }
 
+resource "azurerm_role_assignment" "sp_storage_eventgrid_event_contributor" {
+  scope                = azurerm_resource_group.rg.id
+  role_definition_name = "EventGrid EventSubscription Contributor"
+  principal_id         = azurerm_user_assigned_identity.primary_service_principal.principal_id
+}
+
+
 resource "azurerm_role_assignment" "sp_storage_blob_contributor" {
   scope                = azurerm_storage_account.adls.id
   role_definition_name = "Storage Blob Data Contributor"
@@ -38,8 +45,15 @@ resource "azurerm_role_assignment" "sp_storage_queue_contributor" {
   principal_id         = azurerm_user_assigned_identity.primary_service_principal.principal_id
 }
 
-resource "azurerm_role_assignment" "sp_storage_eventgrid_event_contributor" {
-  scope                = azurerm_resource_group.rg.id
-  role_definition_name = "EventGrid EventSubscription Contributor"
+
+resource "azurerm_role_assignment" "sp_uc_storage_blob_contributor" {
+  scope                = azurerm_storage_account.uc_storage.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.primary_service_principal.principal_id
+}
+
+resource "azurerm_role_assignment" "sp_uc_storage_queue_contributor" {
+  scope                = azurerm_storage_account.uc_storage.id
+  role_definition_name = "Storage Queue Data Contributor"
   principal_id         = azurerm_user_assigned_identity.primary_service_principal.principal_id
 }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,12 +1,3 @@
-# Generate random value for the storage account name
-resource "random_string" "random_suffix" {
-  length  = 8
-  lower   = true
-  numeric = false
-  special = false
-  upper   = false
-}
-
 # Create an ADLS Gen2 storage account with raw and transformed containers
 # Using cool access tier and locally redundant storage for cost control
 resource "azurerm_storage_account" "adls" {
@@ -31,5 +22,36 @@ resource "azurerm_storage_container" "raw" {
 resource "azurerm_storage_container" "transformed" {
   name                  = "transformed"
   storage_account_name    = azurerm_storage_account.adls.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_account" "uc_storage" {
+  name                     = "${var.uc_storage_account_prefix}${random_string.random_suffix.result}"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = var.deployment_location
+  account_tier             = "Standard"
+  access_tier              = "Hot"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "dev"
+  }
+}
+
+resource "azurerm_storage_container" "uc_bronze" {
+  name                  = "bronze"
+  storage_account_name    = azurerm_storage_account.uc_storage.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "uc_silver" {
+  name                  = "silver"
+  storage_account_name    = azurerm_storage_account.uc_storage.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "uc_gold" {
+  name                  = "gold"
+  storage_account_name    = azurerm_storage_account.uc_storage.name
   container_access_type = "private"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,6 +18,12 @@ variable "general_storage_account_prefix" {
   default = "devadls"
 }
 
+variable "uc_storage_account_prefix" {
+  description = "Prefix for ADLS storage account for Unity Catalog"
+  default = "devuc"
+}
+
+
 variable "adf_prefix" {
   description = "Prefix for the ADF instance name"
   default = "dev-adf-"


### PR DESCRIPTION
- Moved random resource to a dedicated file since it is used in multiple resources and not just storage
- Added uc_storage resource with bronze, silver, and gold containers for Databricks Unity Catalog
- Added role assignment resources required for managed identity to be used as a Databricks access connector

Closes #28